### PR TITLE
Added support for BjyProfiler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ In your `index.php` add the following:
 
     define('REQUEST_MICROTIME', microtime(true));
 
+
+If you wish to profile Zend\Db, you have to install and enable [BjyProfiler](https://github.com/bjyoungblood/BjyProfiler). You can do so by running composer's `require` command.
+
+    php composer.phar require bjyoungblood/BjyProfiler:dev-master
+
+Zend Developer Tools will try to grab the Profiler from your Zend\Db adapter instance, using the `Zend\Db\Adapter\Adapter` or `ZDT_Zend_Db` service name.
+
 Redux
 =====
 

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
         "php": ">=5.3.3",
         "zendframework/zendframework": "dev-master"
     },
+    "suggest": {
+        "bjyoungblood/BjyProfiler": "Version: dev-master, allows the usage of the (Zend) Db collector.",
+    },
     "autoload": {
         "psr-0": {
             "ZendDeveloperTools": "src/"

--- a/view/zend-developer-tools/toolbar/db.phtml
+++ b/view/zend-developer-tools/toolbar/db.phtml
@@ -1,59 +1,73 @@
+<?php use BjyProfiler\Db\Profiler\Profiler; ?>
 <div class="zdt-toolbar-entry">
     <div class="zdt-toolbar-preview">
         <img src="data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMy1jMDExIDY2LjE0NTY2MSwgMjAxMi8wMi8wNi0xNDo1NjoyNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoV2luZG93cykiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6NzU1MkQ0QURDODkyMTFFMUE4RDU5MDZBOEM2RTM5QjYiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6NzU1MkQ0QUVDODkyMTFFMUE4RDU5MDZBOEM2RTM5QjYiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo3NTUyRDRBQkM4OTIxMUUxQThENTkwNkE4QzZFMzlCNiIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo3NTUyRDRBQ0M4OTIxMUUxQThENTkwNkE4QzZFMzlCNiIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PryYMQ8AAAN9SURBVHjapFRdSJNhFH6/7dvUzQWbOLacM92UNW1E4WDRhWKhiN0JEUU3/RAIXdiV0I1dKF7oRRe7mCmIonZRJM0agqRgiZIs0VnD5s/mVNRl4eZ+3E/PO76FjBVWBx7O9573fc97znPO+Riv10uOyVXgJnAOOAvkkMziARzAG+BlQUHBLyfMxsYG1bcAMyCJRqORra2tA4fDEfR4PEeQOAOhhxKJBMnLyxPodDpBSUlJrkQiyeX89AMPVCrVIYtD97CwjI6Ouru7u7/Mzc35uAiWgW3gCOBxF+OAFDgDaBCZsr6+XtbS0nKdZdnzsBmYmZmZjwqF4mJxcfGjeDz+an19fYWcUIqKiqhzo8VieVZbW6vCmmEXFhbicrmcuFyux5Q3OLVBuwDKBY02keZHBJwGlKurq9XQ9YAqGAzG6CYLTo7ghHCp3OVA+foG6nzpKcN+CnYlvvnHXxEIBMk1a7fbvRUVFZkykuGyLNMGLU66oFsCVPP39vaI2+02aLXaXJFIRItE/hYjIyMbXV1dU+iO5+zAwMCV2dnZybq6Oqlery9paGjILysrk6jVapFUKs1KjyQcDsdwMQj+/BMTE76pqakfoO1tb2+vqbKykjCDg4MfDAaDCTxOLy0tvWhvb+fPz8/ni8ViLbjKgz3B4/GYVJqwhdCbHvSrq7m52d/Y2FiOs/fpHqhjWLxIuKKYEKGpv5/2KNmBzQE48U25YbkeZOBcAacm4DZnT96PxWLJF9n9/f3vWKRnJqfApepMBclUlFTb8BcXF8Xg6oJGozn1LwWhWFtbO2hra/sE3cMODQ3JQajVbDYbMEb5VVVVcsykKDs7m/3TlOzu7obQcr6xsbFdaHtPT88hikSY4eHh9xiZS36//2lHR8fy9PR0eSAQUGMUZYhcAM6SteAmhsFebHt7OwyqPKWlpZ+bmpqCRqPxDujRmUwmhsUmU1hYSNCDD1tbW2kKbmzO+Xy+yc3NTS8chPh8Pg/2BP3rYExlSqVSKxQK9XjgRorXSCSSrCyLkYlyVU6JGgfUiI5Q/E7S7hD6KNU88DeJRj2kB/4HfX19X5OO4cxptVrVaNQcCF8mk2WftLoY2xA43+ns7HTabLYn8LfEjI+Pk5qaGiEW15B+FQi+jCKJ8EcWw3kWUmGOp4biRcFtEL87v9PpXMEIvoP5NffLIz8FGAAqeUQbl180BwAAAABJRU5ErkJggg==" alt="Database (Zend\Db)">
         <span class="zdt-toolbar-info">
-            <?php echo $this->collector->getQueries(); ?> in <?php echo $this->ZDT_Time($this->collector->getTime()); ?>
+            <?php
+            if ($this->collector->hasProfiler()) {
+                printf('%d in %s', $this->collector->getQueryCount(), $this->ZDT_Time($this->collector->getQueryTime()));
+            } else {
+                echo 'N/A';
+            }
+            ?>
         </span>
     </div>
     <div class="zdt-toolbar-detail">
+        <?php if ($this->collector->hasProfiler()): ?>
         <span class="zdt-toolbar-info zdt-toolbar-info-heading">Queries</span>
         <span class="zdt-toolbar-info">
             <span class="zdt-detail-label">create</span>
-            <span class="zdt-detail-value zdt-detail-value-right"><?php echo $this->collector->getCreateQueries(); ?></span>
+            <span class="zdt-detail-value zdt-detail-value-right"><?php echo $this->collector->getQueryCount(Profiler::INSERT); ?></span>
         </span>
         <span class="zdt-toolbar-info">
             <span class="zdt-detail-label">read</span>
-            <span class="zdt-detail-value zdt-detail-value-right"><?php echo $this->collector->getReadQueries(); ?></span>
+            <span class="zdt-detail-value zdt-detail-value-right"><?php echo $this->collector->getQueryCount(Profiler::SELECT); ?></span>
         </span>
         <span class="zdt-toolbar-info">
             <span class="zdt-detail-label">update</span>
-            <span class="zdt-detail-value zdt-detail-value-right"><?php echo $this->collector->getUpdateQueries(); ?></span>
+            <span class="zdt-detail-value zdt-detail-value-right"><?php echo $this->collector->getQueryCount(Profiler::UPDATE); ?></span>
         </span>
         <span class="zdt-toolbar-info">
             <span class="zdt-detail-label">delete</span>
-            <span class="zdt-detail-value zdt-detail-value-right"><?php echo $this->collector->getDeleteQueries(); ?></span>
+            <span class="zdt-detail-value zdt-detail-value-right"><?php echo $this->collector->getQueryCount(Profiler::DELETE); ?></span>
         </span>
 
         <span class="zdt-toolbar-info zdt-toolbar-info-heading zdt-toolbar-topspacing">Time</span>
         <span class="zdt-toolbar-info">
             <span class="zdt-detail-label">create</span>
-            <span class="zdt-detail-value zdt-detail-value-right"><?php echo $this->ZDT_Time($this->collector->getCreateTime()); ?></span>
+            <span class="zdt-detail-value zdt-detail-value-right"><?php echo $this->collector->getQueryTime(Profiler::INSERT); ?></span>
         </span>
         <span class="zdt-toolbar-info">
             <span class="zdt-detail-label">read</span>
-            <span class="zdt-detail-value zdt-detail-value-right"><?php echo $this->ZDT_Time($this->collector->getReadTime()); ?></span>
+            <span class="zdt-detail-value zdt-detail-value-right"><?php echo $this->collector->getQueryTime(Profiler::SELECT); ?></span>
         </span>
         <span class="zdt-toolbar-info">
             <span class="zdt-detail-label">update</span>
-            <span class="zdt-detail-value zdt-detail-value-right"><?php echo $this->ZDT_Time($this->collector->getUpdateTime()); ?></span>
+            <span class="zdt-detail-value zdt-detail-value-right"><?php echo $this->collector->getQueryTime(Profiler::UPDATE); ?></span>
         </span>
         <span class="zdt-toolbar-info">
             <span class="zdt-detail-label">delete</span>
-            <span class="zdt-detail-value zdt-detail-value-right"><?php echo $this->ZDT_Time($this->collector->getDeleteTime()); ?></span>
+            <span class="zdt-detail-value zdt-detail-value-right"><?php echo $this->collector->getQueryTime(Profiler::DELETE); ?></span>
         </span>
 
         <span class="zdt-toolbar-info zdt-toolbar-info-heading zdt-toolbar-info-redundant zdt-toolbar-topspacing">Total</span>
         <span class="zdt-toolbar-info zdt-toolbar-info-redundant">
             <span class="zdt-detail-label">Queries</span>
             <span class="zdt-detail-value zdt-detail-value-right">
-                <?php echo $this->collector->getQueries(); ?>
+                <?php echo $this->collector->getQueryCount(); ?>
             </span>
         </span>
         <span class="zdt-toolbar-info zdt-toolbar-info-redundant">
             <span class="zdt-detail-label">Time</span>
             <span class="zdt-detail-value zdt-detail-value-right">
-                <?php echo $this->ZDT_Time($this->collector->getTime()); ?>
+                <?php echo $this->ZDT_Time($this->collector->getQueryTime()); ?>
             </span>
         </span>
+        <?php else: ?>
+        <span class="zdt-toolbar-info zdt-toolbar-info-heading">Error</span>
+        <span class="zdt-toolbar-info">
+            You have to install or enable <a href="https://github.com/bjyoungblood/BjyProfiler">@bjyoungblood's Zend\Db Profiler</a> to use this feature.
+        </span>
+        <?php endif ?>
     </div>
 </div>


### PR DESCRIPTION
The Db collector uses now [BjyProfiler](https://github.com/bjyoungblood/BjyProfiler), that means that the minimum PHP version is now 5.3.6 (because of [that](https://github.com/bjyoungblood/BjyProfiler/blob/master/src/BjyProfiler/Db/Adapter/Driver/Mysqli/ProfilingStatement.php#L24)). I can however prepare a PR with a version check for the `debug_backtrace` call.

Added an error text if no `Zend\Db` profiler instance is available.
[![preview](http://i.imgur.com/AOjeB.png)]
