### PR TITLE
Update src/ZendDeveloperTools/Listener/ToolbarListener.php

### DIFF
--- a/src/ZendDeveloperTools/Listener/ToolbarListener.php
+++ b/src/ZendDeveloperTools/Listener/ToolbarListener.php
@@ -21,7 +21,7 @@
 
 namespace ZendDeveloperTools\Listener;
 
-use Zend\Version;
+use Zend\Version\Version;
 use Zend\View\Model\ViewModel;
 use Zend\View\Exception\RuntimeException;
 use ZendDeveloperTools\Options;


### PR DESCRIPTION
fix Class 'Zend\Version' not found
