### PR TITLE
Fix "version_check" toolbar option

### DIFF
--- a/src/ZendDeveloperTools/Options.php
+++ b/src/ZendDeveloperTools/Options.php
@@ -214,7 +214,7 @@ class Options extends AbstractOptions
         }
 
         if (isset($options['version_check'])) {
-            $this->profiler['version_check'] = (boolean) $options['version_check'];
+            $this->toolbar['version_check'] = (boolean) $options['version_check'];
         }
         if (isset($options['position'])) {
             if ($options['position'] !== 'bottom' && $options['position'] !== 'top') {


### PR DESCRIPTION
In \ZendDeveloperTools\Option, the "version_check" wasn't stored on good array. So, the version check was always disabled.
