### PR TITLE
Display the toolbar only for a HTML response

### DIFF
--- a/src/ZendDeveloperTools/Listener/ToolbarListener.php
+++ b/src/ZendDeveloperTools/Listener/ToolbarListener.php
@@ -110,9 +110,14 @@ class ToolbarListener implements ListenerAggregateInterface
     {
         $application = $event->getApplication();
         $request     = $application->getRequest();
-        $response    = $application->getResponse();
 
         if ($request->isXmlHttpRequest()) {
+            return;
+        }
+
+        $response = $application->getResponse();
+        $headers = $response->getHeaders();
+        if ($headers->has('Content-Type') && false !== strpos($headers->get('Content-Type'), 'html')) {
             return;
         }
 


### PR DESCRIPTION
We need to check the content-type header of the response before to
inject the toolbar in the response content. The toolbar can be displayed
only if the content is in HTML format.
