### PR TITLE
Add title attribute to extension display

### DIFF
--- a/view/zend-developer-tools/toolbar/zendframework.phtml
+++ b/view/zend-developer-tools/toolbar/zendframework.phtml
@@ -31,9 +31,9 @@
             <span class="zdt-toolbar-info">
                 <span class="zdt-detail-label">Extensions</span>
                 <span class="zdt-detail-value">
-                    <span class="zdt-toolbar-status zdt-toolbar-status-<?php echo ($this->has_intl) ? 'green' : 'red'; ?>">
-                        intl
-                    </span>
+                    <span class="zdt-toolbar-status zdt-toolbar-status-<?php echo ($this->has_intl) ? 'green' : 'red'; ?>"
+                          title="<?php echo $intlText = 'intl extension ' . ($this->has_intl ? 'enabled' : 'disabled'); ?>"
+                    >intl</span>
                 </span>
             </span>
         </div>


### PR DESCRIPTION
Sorry, but with only 1 extension check (that's turned red), I was
unable to determine if it was just decorative or or informative.
