### PR TITLE
Warning in ZendDeveloperTools/Listener/ToolbarListener.php

### DIFF
--- a/src/ZendDeveloperTools/Listener/ToolbarListener.php
+++ b/src/ZendDeveloperTools/Listener/ToolbarListener.php
@@ -117,7 +117,9 @@ class ToolbarListener implements ListenerAggregateInterface
 
         $response = $application->getResponse();
         $headers = $response->getHeaders();
-        if ($headers->has('Content-Type') && false !== strpos($headers->get('Content-Type'), 'html')) {
+        if ($headers->has('Content-Type')
+            && false !== strpos($headers->get('Content-Type')->getFieldValue(), 'html')
+        ) {
             return;
         }
 


### PR DESCRIPTION
A class HttpHeader don't have a magic method __toString() in version
2.0.*. We need to call a method like toString() or getFieldValue()
instead. fixes #43
