### PR TITLE
Add rule to ignore OSX finder and PhpStorm, Netbeans and Zend Studio pro...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+nbproject
+.idea
+.buildpath
+.project
+.settings/
+.DS_Store


### PR DESCRIPTION
Currently, there is no `.gitignore`.

I added one with rules to ignore
- OSX finder files
- PhpStorm, Zend Studio and Neatbeans project files.
