### PR TITLE
Display the toolbar only for a HTML response (fix)

### DIFF
--- a/src/ZendDeveloperTools/Listener/ToolbarListener.php
+++ b/src/ZendDeveloperTools/Listener/ToolbarListener.php
@@ -118,7 +118,7 @@ class ToolbarListener implements ListenerAggregateInterface
         $response = $application->getResponse();
         $headers = $response->getHeaders();
         if ($headers->has('Content-Type')
-            && false !== strpos($headers->get('Content-Type')->getFieldValue(), 'html')
+            && false === strpos($headers->get('Content-Type')->getFieldValue(), 'html')
         ) {
             return;
         }


### PR DESCRIPTION
I don't know if anyone tested it, but onCollected callback did return prematurely for valid Content-Type header so the toolbar wasn't injected.
