### PR TITLE
Solves #67

### DIFF
--- a/src/ZendDeveloperTools/Listener/ToolbarListener.php
+++ b/src/ZendDeveloperTools/Listener/ToolbarListener.php
@@ -193,7 +193,7 @@ class ToolbarListener implements ListenerAggregateInterface
             $partsLatestRelease = explode('.', $latest);
             $docUri             = sprintf(
                 self::DEV_DOC_URI_PATTERN,
-                $partsLatestRelease[1] == $partsCurrent[1] ? 'latest' : 'develop'
+                current($partsLatestRelease) == $partsCurrent[1] ? 'latest' : 'develop'
             );
         }
 


### PR DESCRIPTION
Steps to reproduce the issue
*Set 'version_check' => true in config
*Load (any) page in Browser
*Set 'version_check' => false in config

Since ZendDeveloperTools\Listener\ToolbarListener->getLatestVersion() returns
array(true, '') when 'version_check', $latest = '' and 
$partsLatestRelease = explode('.', $latest) doesn't have index 1 defined.

See #67
