### PR TITLE
Add PHP version check for defining start time. Get it from

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ Installation
 3. Copy `ZendDeveloperTools/config/zenddevelopertools.local.php.dist` to
    `./config/autoload/zenddevelopertools.local.php`. Change any settings in it
    according to your needs.
-4. Add the following in your `index.php`:
+4. If server version of PHP is lower than 5.4.0 add the following in your `index.php`:
    ```
    define('REQUEST_MICROTIME', microtime(true));
    ```
 
-   **Note:** The displayed execution time in the toolbar will be highly inaccurate if you don't define `REQUEST_MICROTIME`.
+   **Note:** The displayed execution time in the toolbar will be highly inaccurate
+    if you don't define `REQUEST_MICROTIME` at PHP < 5.4.0.
 
 
 If you wish to profile `Zend\Db` queries, you will have to install and enable

--- a/src/ZendDeveloperTools/Collector/TimeCollector.php
+++ b/src/ZendDeveloperTools/Collector/TimeCollector.php
@@ -39,7 +39,9 @@ class TimeCollector extends AbstractCollector implements EventCollectorInterface
      */
     public function collect(MvcEvent $mvcEvent)
     {
-        if (defined('REQUEST_MICROTIME')) {
+        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+            $start = $mvcEvent->getRequest()->getServer()->get('REQUEST_TIME_FLOAT');
+        } elseif (defined('REQUEST_MICROTIME')) {
             $start = REQUEST_MICROTIME;
         } else {
             $start = $mvcEvent->getRequest()->getServer()->get('REQUEST_TIME');


### PR DESCRIPTION
Update to remove unnecessary REQUEST_MICROTIME for ZF 2.3 with minimum requirement PHP 5.4
