### PR TITLE
force -moz-box-sizing to override boostrap 3.

### DIFF
--- a/view/zend-developer-tools/toolbar/toolbar.css
+++ b/view/zend-developer-tools/toolbar/toolbar.css
@@ -15,6 +15,7 @@
     background: -o-linear-gradient(top, #333, #222);
     background: linear-gradient(top, #333, #222);
     font: normal 13px/40px 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    -moz-box-sizing: content-box;
 }
 
 #zend-developer-toolbar a {


### PR DESCRIPTION
As boostrap 3 is integrated to zf2 skeleton...
Forcing this propriety prevents the details to disappear on hover. 
