### PR TITLE
In rtl templates, toolbar blocks goes off the screen

### DIFF
--- a/view/zend-developer-tools/toolbar/toolbar.css
+++ b/view/zend-developer-tools/toolbar/toolbar.css
@@ -15,6 +15,7 @@
     background: -o-linear-gradient(top, #333, #222);
     background: linear-gradient(top, #333, #222);
     font: normal 13px/40px 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    direction: ltr;
 }
 
 #zend-developer-toolbar a {


### PR DESCRIPTION
By making it to be "ltr" explicitly it solves the issue which rises in rtl templates.

In fact in rtl templates when hovering over elements in toolbar , blocks which is being displayed on that time will go off the screen which is really annoying.
