### PR TITLE
[zfcampus/zf-apigility#56] Do not return a value!

### DIFF
--- a/src/ZendDeveloperTools/Listener/EventLoggingListenerAggregate.php
+++ b/src/ZendDeveloperTools/Listener/EventLoggingListenerAggregate.php
@@ -86,7 +86,5 @@ class EventLoggingListenerAggregate implements SharedListenerAggregateInterface
         foreach ($this->collectors as $collector) {
             $collector->collectEvent('application', $event);
         }
-
-        return true; // @TODO workaround, to be removed when https://github.com/zendframework/zf2/pull/6147 is fixed
     }
 }


### PR DESCRIPTION
Returning a value can be used by the object triggering the event to stop 
propagation; as such, any listener that is listening on wildcard events, or, 
typically, more than one event, likely should not return a value.

In this particular case, the logging listener was returning a boolean true 
value. This broke the zf-mvc-auth "authorization" event, as boolean return 
values can be used to short-circuit (they indicate authorization status).

The code inside this method also indicated that the return value was a hack 
until a ZF2 issue was resolved -- and it has been for some time now.

Fixes zfcampus/zf-apigility#56.
