### PR TITLE
Text in toolbar always left align

### DIFF
--- a/view/zend-developer-tools/toolbar/toolbar.css
+++ b/view/zend-developer-tools/toolbar/toolbar.css
@@ -16,6 +16,7 @@
     background: linear-gradient(to bottom, #333, #222);
     font: normal 13px/40px 'Helvetica Neue', Helvetica, Arial, sans-serif;
     direction: ltr;
+    text-align: left;
 }
 
 #zend-developer-toolbar a {


### PR DESCRIPTION
As you have in css:
```css
body {
text-align:center;
}
```
Then some detail box (configs, Doctrine profilter) are text aligned to center.