### PR TITLE
Fix setting of ProfilingAdapter

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -216,7 +216,8 @@ class Module implements
                             $p = true;
                             $db->setProfiler($adapter->getProfiler());
                         }
-                    } elseif (!$p && $sm->has('Zend\Db\Adapter\ProfilingAdapter')) {
+                    }
+                    if (!$p && $sm->has('Zend\Db\Adapter\ProfilingAdapter')) {
                         $adapter = $sm->get('Zend\Db\Adapter\ProfilingAdapter');
                         if ($adapter instanceof ProfilingAdapter) {
                             $db->setProfiler($adapter->getProfiler());


### PR DESCRIPTION
Since there was the variable $p I figured that there should be 2 ifs instead of if and elseif.
By splitting this up, it'll be possible to use Zend\Db\Adapter\ProfilingAdapter even if Zend\Db\Adapter\Adapter is set and NOT an instanceof ProfilingAdapter