### PR TITLE
change toolbar injection method to insert toolbar only before the last body tag

### DIFF
--- a/src/ZendDeveloperTools/Listener/ToolbarListener.php
+++ b/src/ZendDeveloperTools/Listener/ToolbarListener.php
@@ -163,9 +163,9 @@ class ToolbarListener implements ListenerAggregateInterface
         $toolbarJs->setTemplate('zend-developer-tools/toolbar/script');
         $script       = $this->renderer->render($toolbarJs);
 
-        $injected    = preg_replace('/<\/body>/i', $toolbar . "\n</body>", $response->getBody(), 1);
+        $injected    = preg_replace('/<\/body>(?![\s\S]*<\/body>)/i', $toolbar . "\n</body>", $response->getBody(), 1);
         $injected    = preg_replace('/<\/head>/i', $style . "\n</head>", $injected, 1);
-        $injected    = preg_replace('/<\/body>/i', $script . "\n</body>", $injected, 1);
+        $injected    = preg_replace('/<\/body>(?![\s\S]*<\/body>)/i', $script . "\n</body>", $injected, 1);
 
         $response->setContent($injected);
     }


### PR DESCRIPTION
I'm using [Kint](https://github.com/raveren/kint) library to dump variables, because I find it awesome. It worked pretty well until I updated it to the latest stable release (1.0.2) then it got weird. It looked like zdt toolbar was being injected in-between every Kint debug I put in templates. I found the culprit to be this gem from within html outputted by Kint:
```javascript
b.document.write("<html><head><title>Kint ("+(new Date).toISOString()+')</title><meta charset="utf-8">'+document.getElementsByClassName("-kint-js")[0].outerHTML+document.getElementsByClassName("-kint-css")[0].outerHTML+'</head><body><input style="width: 100%" placeholder="Take some notes!"><div class="kint">'+a.parentNode.outerHTML+"</div></body>"),b.document.close()},w=function(a,b){function c(a){var c=1===b?a.replace(/^#/,""):a;if(isNaN(c))return a.trim().toLocaleLowerCase();c=parseFloat(c);return isNaN(c)?
```
I do not even want to know what that is for. That is just too much weirdness for [this code](https://github.com/zendframework/ZendDeveloperTools/blob/master/src/ZendDeveloperTools/Listener/ToolbarListener.php#L166):
```php
$injected    = preg_replace('/<\/body>/i', $toolbar . "\n</body>", $response->getBody(), 1);
$injected    = preg_replace('/<\/head>/i', $style . "\n</head>", $injected, 1);
$injected    = preg_replace('/<\/body>/i', $script . "\n</body>", $injected, 1);
```
So I modified the regexes for body injection to happen only at the last found occurrence. Same thing happening to `head` tag shouldn't be a problem, since `preg_replace` already limits itself to the first match. Works for me and it shouldn't ruin it for others. What do guys you think?