### PR TITLE
Enhancement/security

### DIFF
--- a/tests/Collector/ConfigCollectionTest.php
+++ b/tests/Collector/ConfigCollectionTest.php
@@ -27,4 +27,57 @@ class ConfigCollectorTest extends \PHPUnit_Framework_TestCase
 
         $collector->collect($mvcEvent);
     }
+
+    public function testCollectorObfuscateRiskyKeyValues()
+    {
+        $config = array(
+            'username' => 'fooUser',
+            'password' => 'password',
+            'nested' => array(
+                'dsn' => 'hostname:localhost;username:user;pass:password',
+            ),
+        );
+
+        $collector = new ConfigCollector();
+
+        $application = $this->getMockBuilder("Zend\Mvc\Application")
+            ->disableOriginalConstructor()
+            ->getMock();
+        $serviceManager = $this->getMockBuilder("Zend\ServiceManager\ServiceManager")
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $serviceManager
+            ->expects($this->any())
+            ->method('get')
+            ->willReturn($config);
+
+        $serviceManager
+            ->expects($this->any())
+            ->method('has')
+            ->willReturn(true);
+
+        $application
+            ->expects($this->once())
+            ->method("getServiceManager")
+            ->willReturn($serviceManager);
+
+        $mvcEvent = $this->getMockBuilder("Zend\Mvc\MvcEvent")
+            ->getMock();
+
+        $mvcEvent->method("getApplication")->willReturn($application);
+
+        $collector->collect($mvcEvent);
+
+        $returnConfig = $collector->getConfig();
+
+        $replacedCount = substr_count(var_export($returnConfig, true), $collector::OBFUSCATE_STRING);
+        $this->assertEquals(3, $replacedCount);
+        $this->assertCount(count($config), $returnConfig);
+
+        $this->assertEquals($collector::OBFUSCATE_STRING, $returnConfig['username']);
+        $this->assertEquals($collector::OBFUSCATE_STRING, $returnConfig['password']);
+        $this->assertEquals($collector::OBFUSCATE_STRING, $returnConfig['nested']['dsn']);
+
+    }
 }


### PR DESCRIPTION
This PR

- [x] adds a method to obfuscate risky config key values like
 - ``password, username, pwd, dsn, ... ``

As i see many developers don't know or forget that enable the dev toolbar online, expose their complete config credentials. 

I know this is a development module but it think it is fair to force developers to look at such config values directly in the files.

Before:

```php
Array
(
    [username] => superSecretUsername
    [password] => superSecretPassword
    [nested] => Array
        (
            [dsn] => superSecretConnectionString
        )
)
```

After:

```php
Array
(
    [username] => ******
    [password] => ******
    [nested] => Array
        (
            [dsn] => ******
        )
)
```

ping @Ocramius 