### PR TITLE
Argument 1 passed to ZendDeveloperTools\Listener\EventLoggingListenerAggregate::onCollectEvent() must be an instance of Zend\EventManager\Event

### DIFF
--- a/src/ZendDeveloperTools/Collector/EventCollectorInterface.php
+++ b/src/ZendDeveloperTools/Collector/EventCollectorInterface.php
@@ -9,7 +9,7 @@
 
 namespace ZendDeveloperTools\Collector;
 
-use Zend\EventManager\Event;
+use Zend\EventManager\EventInterface;
 
 /**
  * Event Data Collector Interface.
@@ -23,5 +23,5 @@ interface EventCollectorInterface
      * @param string $id
      * @param Event  $event
      */
-    public function collectEvent($id, Event $event);
+    public function collectEvent($id, EventInterface $event);
 }

--- a/src/ZendDeveloperTools/Collector/MemoryCollector.php
+++ b/src/ZendDeveloperTools/Collector/MemoryCollector.php
@@ -9,7 +9,7 @@
 namespace ZendDeveloperTools\Collector;
 
 use Zend\Mvc\MvcEvent;
-use Zend\EventManager\Event;
+use Zend\EventManager\EventInterface;
 use ZendDeveloperTools\EventLogging\EventContextProvider;
 
 /**
@@ -50,9 +50,9 @@ class MemoryCollector extends AbstractCollector implements EventCollectorInterfa
      * Saves the current memory usage.
      *
      * @param string $id
-     * @param Event  $event
+     * @param EventInterface  $event
      */
-    public function collectEvent($id, Event $event)
+    public function collectEvent($id, EventInterface $event)
     {
         $contextProvider   = new EventContextProvider($event);
         $context['name']   = $contextProvider->getEvent()->getName();

--- a/src/ZendDeveloperTools/Collector/TimeCollector.php
+++ b/src/ZendDeveloperTools/Collector/TimeCollector.php
@@ -9,7 +9,7 @@
 namespace ZendDeveloperTools\Collector;
 
 use Zend\Mvc\MvcEvent;
-use Zend\EventManager\Event;
+use Zend\EventManager\EventInterface;
 use ZendDeveloperTools\EventLogging\EventContextProvider;
 
 /**

--- a/src/ZendDeveloperTools/Collector/TimeCollector.php
+++ b/src/ZendDeveloperTools/Collector/TimeCollector.php
@@ -58,9 +58,9 @@ class TimeCollector extends AbstractCollector implements EventCollectorInterface
      * Saves the current time in microseconds for a specific event.
      *
      * @param string $id
-     * @param Event  $event
+     * @param EventInterface  $event
      */
-    public function collectEvent($id, Event $event)
+    public function collectEvent($id, EventInterface $event)
     {
         $contextProvider   = new EventContextProvider($event);
         $context['time']   = microtime(true);

--- a/src/ZendDeveloperTools/Listener/EventLoggingListenerAggregate.php
+++ b/src/ZendDeveloperTools/Listener/EventLoggingListenerAggregate.php
@@ -9,7 +9,7 @@
 
 namespace ZendDeveloperTools\Listener;
 
-use Zend\EventManager\Event;
+use Zend\EventManager\EventInterface;
 use Zend\EventManager\SharedEventManagerInterface;
 use Zend\EventManager\SharedListenerAggregateInterface;
 use Zend\ServiceManager\Exception\ServiceNotFoundException;
@@ -75,13 +75,13 @@ class EventLoggingListenerAggregate implements SharedListenerAggregateInterface
     /**
      * Callback to process events
      *
-     * @param Event $event
+     * @param EventInterface $event
      *
      * @return bool
      *
      * @throws ServiceNotFoundException
      */
-    public function onCollectEvent(Event $event)
+    public function onCollectEvent(EventInterface $event)
     {
         foreach ($this->collectors as $collector) {
             $collector->collectEvent('application', $event);


### PR DESCRIPTION
I have been using a custom event implementing interface `Zend\EventManager\EventInterface` without extending from the class `Zend\EventManager\Event`. When such and event is triggered within my application and ZendDeveloperTools is enabled, I receive the following exception message:

> Catchable fatal error: Argument 1 passed to ZendDeveloperTools\Listener\EventLoggingListenerAggregate::onCollectEvent() must be an instance of Zend\EventManager\Event

The following classes currently type hint on `Zend\EventManager\Event`; I propose these are updated to use  `Zend\EventManager\EventInterface` instead.
- ZendDeveloperTools/Collector/EventCollectorInterface.php
- ZendDeveloperTools/Collector/MemoryCollector.php
- ZendDeveloperTools/Collector/TimeCollector.php
- ZendDeveloperTools/Listener/EventLoggingListenerAggregate.php
