### PR TITLE
Page for background-collection

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,5 +1,19 @@
 <?php
 return array(
+    'router' => array(
+        'routes' => array(
+            'zdtBackgroundRequests' => array(
+                'type' => 'segment',
+                'options' => array(
+                    'route' => '/zdt-background-requests[/:uuid][/]',
+                    'defaults' => array(
+                        'controller' => 'zenddevelopertools',
+                        'action' => 'background-requests',
+                    ),
+                ),
+            ),
+        ),
+    ),
     'view_manager' => array(
         'template_path_stack' => array(
             'zenddevelopertools' => __DIR__ . '/../view',

--- a/config/zenddevelopertools.local.php.dist
+++ b/config/zenddevelopertools.local.php.dist
@@ -94,6 +94,18 @@ return array(
             'identifiers' => array()
         ),
         /**
+         * General Background-Request settings
+         */
+        'backgroundrequests' => array(
+            /**
+             * Enables or disables the Background-Requests-Page
+             *
+             * Expects: bool
+             * Default: false
+             */
+            'enabled' => true,
+        ),
+        /**
          * General Toolbar settings
          */
         'toolbar' => array(

--- a/src/ZendDeveloperTools/Controller/DeveloperToolsController.php
+++ b/src/ZendDeveloperTools/Controller/DeveloperToolsController.php
@@ -12,7 +12,7 @@ namespace ZendDeveloperTools\Controller;
 use Zend\View\Model\ViewModel;
 use Zend\Mvc\Controller\AbstractActionController;
 
-class IndexController extends AbstractActionController
+class DeveloperToolsController extends AbstractActionController
 {
     public function indexAction()
     {

--- a/src/ZendDeveloperTools/Controller/DeveloperToolsController.php
+++ b/src/ZendDeveloperTools/Controller/DeveloperToolsController.php
@@ -11,11 +11,41 @@ namespace ZendDeveloperTools\Controller;
 
 use Zend\View\Model\ViewModel;
 use Zend\Mvc\Controller\AbstractActionController;
+use ZendDeveloperTools\Options;
 
 class DeveloperToolsController extends AbstractActionController
 {
+    /**
+     * @var Options
+     */
+    protected $options;
+
+    public function __construct(Options $options)
+    {
+        $this->options = $options;
+    }
+
     public function indexAction()
     {
         return new ViewModel();
+    }
+
+    public function backgroundRequestsAction()
+    {
+        $this->options->setToolbar(['enabled' => false]);
+
+        /*TODO: make this configurable */
+        $this->options->setBackgroundrequests(['enabled' => false]);
+
+        $toolbars = array();
+        $cacheDir = $this->options->getCacheDir();
+
+        foreach (glob($cacheDir . '/ZDT_*.entries') as $entriesFileName) {
+            $toolbars[] = unserialize(file_get_contents($entriesFileName));
+        }
+
+        $model = new ViewModel(['toolbars' => $toolbars]);
+        $model->setTerminal(true);
+        return $model;
     }
 }

--- a/src/ZendDeveloperTools/Listener/ToolbarListener.php
+++ b/src/ZendDeveloperTools/Listener/ToolbarListener.php
@@ -120,7 +120,16 @@ class ToolbarListener implements ListenerAggregateInterface
         $application = $event->getApplication();
         $request     = $application->getRequest();
 
-        if ($request->isXmlHttpRequest()) {
+        if ($this->options->isBackgroundrequestsEnabled()) {
+            $toolbar = array(
+                'renderedEntries' => $this->renderEntries($event),
+                'timestamp' => microtime(true),
+            );
+            $cacheDir = $this->options->getCacheDir();
+            file_put_contents($cacheDir . '/ZDT_' . microtime(true) . '.entries', serialize($toolbar));
+        }
+
+        if ($request->isXmlHttpRequest() || !$this->options->isToolbarEnabled()) {
             return;
         }
 
@@ -183,7 +192,7 @@ class ToolbarListener implements ListenerAggregateInterface
         $report  = $event->getReport();
 
         list($isLatest, $latest) = $this->getLatestVersion(Version::VERSION);
-        
+
         if (false === ($pos = strpos(Version::VERSION, 'dev'))) {
             $docUri = sprintf(self::DOC_URI_PATTERN, substr(Version::VERSION, 0, 3));
         } else { // unreleased dev branch - compare minor part of versions

--- a/src/ZendDeveloperTools/Options.php
+++ b/src/ZendDeveloperTools/Options.php
@@ -70,6 +70,13 @@ class Options extends AbstractOptions
     );
 
     /**
+     * @var array
+     */
+    protected $backgroundrequests = array(
+        'enabled' => false,
+    );
+
+    /**
      * Overloading Constructor.
      *
      * @param  array|Traversable|null $options
@@ -407,6 +414,28 @@ class Options extends AbstractOptions
     public function getToolbarEntries()
     {
         return $this->toolbar['entries'];
+    }
+
+    /**
+     * Sets BackgroundRequest options.
+     *
+     * @param array $options
+     */
+    public function setBackgroundrequests($options)
+    {
+        if (isset($options['enabled'])) {
+            $this->backgroundrequests['enabled'] = (bool) $options['enabled'];
+        }
+    }
+
+    /**
+     * Is the background-request-collection enabled?
+     *
+     * @return bool
+     */
+    public function isBackgroundrequestsEnabled()
+    {
+        return $this->backgroundrequests['enabled'];
     }
 
     // todo: storage and firephp options.

--- a/view/zend-developer-tools/developer-tools/background-requests.phtml
+++ b/view/zend-developer-tools/developer-tools/background-requests.phtml
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Zend Developer Tools for Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/ZendDeveloperTools for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+?>
+
+<html>
+<head>
+<?php echo $this->partial('zend-developer-tools/toolbar/style', ['position' => 'stack']); ?>
+</head>
+
+<body>
+<?php
+foreach ($toolbars as $toolbar) {
+    echo $this->partial(
+        'zend-developer-tools/toolbar/toolbar',
+        array(
+            'entries' => $toolbar['renderedEntries'],
+            'multitoolbar' => true,
+        )
+    );
+}
+
+?>
+</body>
+</html>

--- a/view/zend-developer-tools/toolbar/style.phtml
+++ b/view/zend-developer-tools/toolbar/style.phtml
@@ -3,7 +3,7 @@
 <?php include __DIR__ . '/toolbar.css'; ?>
 
 <?php if ($this->position === 'top') : ?>
-#zend-developer-toolbar {
+.zend-developer-toolbar {
     top: 0;
     bottom: auto;
     border-top: 0;
@@ -22,6 +22,30 @@
     bottom: auto;
     border-top: 0;
     border-bottom: 10px solid #68B604;
+}
+<?php elseif ($this->position === 'stack') : ?>
+.zend-developer-toolbar {
+    position: inherit;
+    display:block;
+    clear:both;
+}
+
+.zdt-toolbar-detail {
+    top: auto;
+    bottom: auto;
+}
+
+.zdt-toolbar-detail:before,
+.zdt-toolbar-detail:after {
+    left: 14px;
+    top: -10px;
+    bottom: auto;
+    border-top: 0;
+    border-bottom: 10px solid #68B604;
+}
+
+.zdt-toolbar-entry:hover .zdt-toolbar-detail {
+    box-shadow: rgba(255, 255, 255, 0.75) 0 0 7px;
 }
 <?php endif; ?>
 </style>

--- a/view/zend-developer-tools/toolbar/toolbar.css
+++ b/view/zend-developer-tools/toolbar/toolbar.css
@@ -1,4 +1,4 @@
-#zend-developer-toolbar {
+.zend-developer-toolbar {
     left: 0;
     bottom: 0;
     width: 100%;
@@ -19,12 +19,12 @@
     text-align: left;
 }
 
-#zend-developer-toolbar a {
+.zend-developer-toolbar a {
     color: #80dc09;
     text-decoration: none;
 }
 
-#zend-developer-toolbar a:hover {
+.zend-developer-toolbar a:hover {
     text-decoration: underline;
 }
 
@@ -226,7 +226,7 @@
     color: #9d9d9d;
 }
 
-#zend-developer-toolbar .zdf-toolbar-hide-button {
+.zend-developer-toolbar .zdf-toolbar-hide-button {
     top: 0;
     right: 8px;
     color: #bebebe;
@@ -236,17 +236,17 @@
     text-decoration: none;
 }
 
-#zend-developer-toolbar .zdf-toolbar-hide-button:hover {
+.zend-developer-toolbar .zdf-toolbar-hide-button:hover {
     color: #eb4a4a;
     text-decoration: none;
 }
 
-#zend-developer-toolbar .zdt-toolbar-entry .zdt-toolbar-detail,#zend-developer-toolbar .zdt-toolbar-entry .zdt-toolbar-info {
+.zend-developer-toolbar .zdt-toolbar-entry .zdt-toolbar-detail,.zend-developer-toolbar .zdt-toolbar-entry .zdt-toolbar-info {
     font-size: 11px;
     max-width: 700px;
 }
 
-#zend-developer-toolbar .zdt-toolbar-info .zdt-detail-value pre {
+.zend-developer-toolbar .zdt-toolbar-info .zdt-detail-value pre {
     max-height: 350px;
     max-width: 650px;
     overflow-y: scroll;
@@ -289,7 +289,7 @@
 }
 
 @media print {
-    #zend-developer-toolbar {
+    .zend-developer-toolbar {
         display: none;
     }
 }

--- a/view/zend-developer-tools/toolbar/toolbar.phtml
+++ b/view/zend-developer-tools/toolbar/toolbar.phtml
@@ -1,5 +1,9 @@
 <!-- START Zend Developer Toolbar -->
-<div id="zend-developer-toolbar">
+<?php if (isset($this->multitoolbar) && $this->multitoolbar): ?>
+<div class="zend-developer-toolbar">
+<?php else: ?>
+<div id="zend-developer-toolbar" class="zend-developer-toolbar">
+<?php endif; ?>
     <?php foreach ($this->entries as $entry): ?>
         <?php echo $entry; ?>
     <?php endforeach; ?>


### PR DESCRIPTION
this PR sets up a page, where you can view former collected toolbar entries by accessing the route /zdt-background-reque.

Known Bugs:
- It’s ugly
- If you scroll to the page’s bottom, it’s horrible to read the bar’s content
- it uses a very high amount of memory

Missing:
- Tests
- Some cookie-stuff to assign and filter the requests (that’s, what the :uuid in the route is for)
- A way to cleanup the cache
- Review
