### PR TITLE
never call DB Adapter service if no 'db' config provided

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -200,7 +200,7 @@ class Module implements
                     $p  = false;
                     $db = new Collector\DbCollector();
 
-                    if ($sm->has('Zend\Db\Adapter\Adapter')) {
+                    if ($sm->has('Zend\Db\Adapter\Adapter') && isset($sm->get('config')['db'])) {
                         $adapter = $sm->get('Zend\Db\Adapter\Adapter');
                         if ($adapter instanceof ProfilingAdapter) {
                             $p = true;
@@ -208,7 +208,7 @@ class Module implements
                         }
                     }
 
-                    if (! $p && $sm->has('Zend\Db\Adapter\AdapterInterface')) {
+                    if (! $p && $sm->has('Zend\Db\Adapter\AdapterInterface') && isset($sm->get('config')['db']) ) {
                         $adapter = $sm->get('Zend\Db\Adapter\AdapterInterface');
                         if ($adapter instanceof ProfilingAdapter) {
                             $p = true;

--- a/src/Module.php
+++ b/src/Module.php
@@ -208,7 +208,7 @@ class Module implements
                         }
                     }
 
-                    if (! $p && $sm->has('Zend\Db\Adapter\AdapterInterface') && isset($sm->get('config')['db']) ) {
+                    if (! $p && $sm->has('Zend\Db\Adapter\AdapterInterface') && isset($sm->get('config')['db'])) {
                         $adapter = $sm->get('Zend\Db\Adapter\AdapterInterface');
                         if ($adapter instanceof ProfilingAdapter) {
                             $p = true;


### PR DESCRIPTION
Use case:
- composer require zendframework/zend-db
- register as module
- refresh
- got undefined index 'db'

For new user that "just try" and see the 'undefined index "db"', it will stopping user to continue learning ;)