### PR TITLE
Remove typehint from constructor

### DIFF
--- a/src/Exception/SerializableException.php
+++ b/src/Exception/SerializableException.php
@@ -21,9 +21,9 @@ class SerializableException implements \Serializable
     /**
      * Saves the exception data in an array.
      *
-     * @param \Exception $exception
+     * @param \Throwable|\Exception $exception
      */
-    public function __construct(\Exception $exception)
+    public function __construct($exception)
     {
         $this->data = [
             'code'     => $exception->getCode(),


### PR DESCRIPTION
- Removes the typehint for the `$exception` argument, to allow either
  `Exception` or `Throwable` to be provided.