### PR TITLE
#94 Fix unix path: zenddevelopertools -> ZendDeveloperTools

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -2,7 +2,7 @@
 return array(
     'view_manager' => array(
         'template_path_stack' => array(
-            'zenddevelopertools' => __DIR__ . '/../view',
+            'ZendDeveloperTools' => __DIR__ . '/../view',
         ),
     ),
 );


### PR DESCRIPTION
Otherwise linux throws exception:

Fatal error: Uncaught Zend\View\Exception\RuntimeException: Zend\View\Renderer\PhpRenderer::render: Unable to render template "zend-developer-tools/toolbar/zendframework"