### PR TITLE
Escape "$" in toolbar content

### DIFF
--- a/src/Listener/ToolbarListener.php
+++ b/src/Listener/ToolbarListener.php
@@ -141,9 +141,14 @@ class ToolbarListener implements ListenerAggregateInterface
         $toolbarJs->setTemplate('zend-developer-tools/toolbar/script');
         $script      = $this->renderer->render($toolbarJs);
 
-        $toolbar     = str_replace('$', '\$', $toolbar);
-        $injected    = preg_replace('/<\/body>(?![\s\S]*<\/body>)/i', $toolbar . $script . "\n</body>", $response->getBody(), 1);
-        $injected    = preg_replace('/<\/head>/i', $style . "\n</head>", $injected, 1);
+        $toolbar  = str_replace('$', '\$', $toolbar);
+        $injected = preg_replace(
+            '/<\/body>(?![\s\S]*<\/body>)/i',
+            $toolbar . $script . "\n</body>",
+            $response->getBody(),
+            1
+        );
+        $injected = preg_replace('/<\/head>/i', $style . "\n</head>", $injected, 1);
 
         $response->setContent($injected);
     }

--- a/src/Listener/ToolbarListener.php
+++ b/src/Listener/ToolbarListener.php
@@ -137,13 +137,13 @@ class ToolbarListener implements ListenerAggregateInterface
         $toolbarCss->setTemplate('zend-developer-tools/toolbar/style');
         $style       = $this->renderer->render($toolbarCss);
 
-        $toolbarJs  = new ViewModel();
+        $toolbarJs   = new ViewModel();
         $toolbarJs->setTemplate('zend-developer-tools/toolbar/script');
-        $script       = $this->renderer->render($toolbarJs);
+        $script      = $this->renderer->render($toolbarJs);
 
-        $injected    = preg_replace('/<\/body>(?![\s\S]*<\/body>)/i', $toolbar . "\n</body>", $response->getBody(), 1);
+        $toolbar     = str_replace('$', '\$', $toolbar);
+        $injected    = preg_replace('/<\/body>(?![\s\S]*<\/body>)/i', $toolbar . $script . "\n</body>", $response->getBody(), 1);
         $injected    = preg_replace('/<\/head>/i', $style . "\n</head>", $injected, 1);
-        $injected    = preg_replace('/<\/body>(?![\s\S]*<\/body>)/i', $script . "\n</body>", $injected, 1);
 
         $response->setContent($injected);
     }


### PR DESCRIPTION
I tried to display the string "$1", "$2" or any numeric after a dollar sign in the toolbar content and it failed. It just got filtered out by the toolbar listener.

After debugging I found the culprit in the ToolbarListener: preg_replace uses $0 .. $99 as replacement targets. 
Escaping all "$" prior to the preg_replace call fixes that.
