### PR TITLE
Fix: Remove useless return statements

### DIFF
--- a/src/Collector/DbCollector.php
+++ b/src/Collector/DbCollector.php
@@ -44,7 +44,6 @@ class DbCollector implements CollectorInterface, AutoHideInterface, \Serializabl
      */
     public function collect(MvcEvent $mvcEvent)
     {
-        return;
     }
 
     /**

--- a/src/Report.php
+++ b/src/Report.php
@@ -176,7 +176,6 @@ class Report implements ReportInterface
         if (isset($this->collectors[$name])) {
             return $this->collectors[$name];
         }
-        return;
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] removes useless `return` statements