### PR TITLE
Use lowercase `config` key to get configuration from container

### DIFF
--- a/src/Collector/ConfigCollector.php
+++ b/src/Collector/ConfigCollector.php
@@ -59,8 +59,8 @@ class ConfigCollector implements CollectorInterface, Serializable
 
         $serviceLocator = $application->getServiceManager();
 
-        if ($serviceLocator->has('Config')) {
-            $this->config = $this->makeArraySerializable($serviceLocator->get('Config'));
+        if ($serviceLocator->has('config')) {
+            $this->config = $this->makeArraySerializable($serviceLocator->get('config'));
         }
 
         if ($serviceLocator->has('ApplicationConfig')) {


### PR DESCRIPTION
- [x] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->
